### PR TITLE
Dynamic version

### DIFF
--- a/spotinst_ocean_controller/main.tf
+++ b/spotinst_ocean_controller/main.tf
@@ -129,7 +129,7 @@ resource "kubernetes_deployment" "default" {
       spec {
 
         container {
-          image = "spotinst/kubernetes-cluster-controller:1.0.30"
+          image = "spotinst/kubernetes-cluster-controller:${data.external.version.result["version"]}"
           name  = "spotinst-kubernetes-cluster-controller"
           image_pull_policy = "Always"
 
@@ -212,4 +212,6 @@ resource "kubernetes_deployment" "default" {
   }
 }
 
-
+data "external" "version" {
+  program = ["curl", "https://s3-eu-west-1.amazonaws.com/spotinst-vers/controller.json"]
+}

--- a/spotinst_ocean_controller/main.tf
+++ b/spotinst_ocean_controller/main.tf
@@ -95,7 +95,7 @@ resource "kubernetes_cluster_role_binding" "default" {
     api_group = ""
     kind = "ServiceAccount"
     name = "spotinst-kubernetes-cluster-controller"
-    namespace = "kube-system" 
+    namespace = "kube-system"
   }
 }
 
@@ -104,7 +104,7 @@ resource "kubernetes_cluster_role_binding" "default" {
 resource "kubernetes_deployment" "default" {
   metadata {
     name = "spotinst-kubernetes-cluster-controller"
-    namespace = "kube-system" 
+    namespace = "kube-system"
     labels {
       k8s-app = "spotinst-kubernetes-cluster-controller"
     }
@@ -185,7 +185,7 @@ resource "kubernetes_deployment" "default" {
               }
             }
           }
-        }  
+        }
 
         volume {
           name = "spotinst-kubernetes-cluster-controller-certs"
@@ -205,7 +205,7 @@ resource "kubernetes_deployment" "default" {
             secret_name = "${kubernetes_service_account.default.default_secret_name}"
           }
         }
-        
+
         service_account_name = "spotinst-kubernetes-cluster-controller"
       }
     }


### PR DESCRIPTION
Implementing dynamic version control to push updates without hard terraform updates.

Currently the version is hard coded and pushing through new versions is not being maintained in the terraform repo. The commit will require a text file in an external source such as S3 to push updates dynamically to the terraform repo.

@todo: Link needs to be updated to reflect a Spotinst data source, for example spotinst-public S3 bucket.

A similar concept is currently used by the Spotinst team to manage the controller as follows
`kubectl apply -f http://spotinst-public.s3.amazonaws.com/integrations/kubernetes/cluster-controller/spotinst-kubernetes-cluster-controller.yaml`

A similar file will need to be created in this S3 bucket for this to be fully implemented and the example link changed in the pull request. The file format as per the pull request is as follows `https://s3-eu-west-1.amazonaws.com/spotinst-vers/controller.json `