### PR TITLE
Add module for creating Spotinst <> AWS connection resources

### DIFF
--- a/spotinst_aws_connection/README.md
+++ b/spotinst_aws_connection/README.md
@@ -1,0 +1,27 @@
+# spotinst_aws_connection
+
+This module setups all IAM resources that are necessary to connect a Spotinst account to an AWS account.
+
+## Example Use
+
+```
+module "spotinst_aws_connection" {
+  source = "github.com/spotinst/terraform-spotinst-modules//spotinst_aws_connection/?ref=v0.2.0"
+
+  spotinst_account_id = ""
+  spotinst_external_id = ""
+}
+```
+
+## Variables
+
+Enter as provided during account creation in the Spotinst web interface.
+
+* spotinst_account_id
+* spotinst_external_id
+
+## Outputs
+
+You will need this to enter the role in the Spotinst web interface.
+
+* spotinst_role_arn

--- a/spotinst_aws_connection/main.tf
+++ b/spotinst_aws_connection/main.tf
@@ -1,0 +1,314 @@
+resource "aws_iam_policy" "spotinst_policy" {
+  name        = "SpotinstPolicy"
+  description = "Used by Spotinst to control resources"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GeneralSpotInstancesAccess",
+      "Action": [
+        "ec2:RequestSpotInstances",
+        "ec2:CancelSpotInstanceRequests",
+        "ec2:CreateSpotDatafeedSubscription",
+        "ec2:Describe*",
+        "ec2:AssociateAddress",
+        "ec2:AttachVolume",
+        "ec2:ConfirmProductInstance",
+        "ec2:CopyImage",
+        "ec2:CopySnapshot",
+        "ec2:CreateImage",
+        "ec2:CreateSnapshot",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteTags",
+        "ec2:DisassociateAddress",
+        "ec2:ModifyImageAttribute",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:MonitorInstances",
+        "ec2:RebootInstances",
+        "ec2:RegisterImage",
+        "ec2:RunInstances",
+        "ec2:StartInstances",
+        "ec2:StopInstances",
+        "ec2:TerminateInstances",
+        "ec2:UnassignPrivateIpAddresses",
+        "ec2:DeregisterImage",
+        "ec2:DeleteSnapshot",
+        "ec2:DeleteVolume",
+        "ec2:ModifyReservedInstances",
+        "ec2:CreateReservedInstancesListing",
+        "ec2:CancelReservedInstancesListing",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessELB",
+      "Action": [
+        "elasticloadbalancing:Describe*",
+        "elasticloadbalancing:Deregister*",
+        "elasticloadbalancing:Register*",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer",
+        "elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessCloudWatch",
+      "Action": [
+        "cloudwatch:DescribeAlarmHistory",
+        "cloudwatch:DescribeAlarms",
+        "cloudwatch:DescribeAlarmsForMetric",
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics",
+        "cloudwatch:PutMetricData",
+        "cloudwatch:PutMetricAlarm"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessSNS",
+      "Action": [
+        "sns:Publish",
+        "sns:ListTopics",
+        "sns:CreateTopic",
+        "sns:GetTopicAttributes",
+        "sns:ListSubscriptionsByTopic",
+        "sns:Subscribe"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessIAM",
+      "Action": [
+        "iam:AddRoleToInstanceProfile",
+        "iam:ListInstanceProfiles",
+        "iam:ListInstanceProfilesForRole",
+        "iam:PassRole",
+        "iam:ListRoles",
+        "iam:ListAccountAliases",
+        "iam:GetPolicyVersion",
+        "iam:ListPolicies",
+        "iam:GetPolicy",
+        "iam:ListAttachedRolePolicies",
+        "organizations:ListAccounts",
+        "iam:CreateServiceLinkedRole",
+        "iam:PutRolePolicy",
+        "iam:GetInstanceProfile",
+        "iam:GetRolePolicy",
+        "iam:ListRolePolicies"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "GeneralAccessElaticBeanstalk",
+      "Action": [
+        "elasticbeanstalk:Describe*",
+        "elasticbeanstalk:RequestEnvironmentInfo",
+        "elasticbeanstalk:RetrieveEnvironmentInfo",
+        "elasticbeanstalk:ValidateConfigurationSettings",
+        "elasticbeanstalk:UpdateEnvironment",
+        "elasticbeanstalk:ListPlatformVersions",
+        "cloudformation:GetTemplate",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:DescribeStackResource",
+        "cloudformation:DescribeStacks",
+        "cloudformation:ListStackResources",
+        "cloudformation:UpdateStack",
+        "cloudformation:DescribeStackEvents",
+        "logs:PutRetentionPolicy",
+        "logs:createLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessAutoScalingGroups",
+      "Action": [
+        "autoscaling:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessEks",
+      "Action": [
+        "eks:ListClusters"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessEMR",
+      "Action": [
+        "elasticmapreduce:*",
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessECS",
+      "Action": [
+        "ecs:List*",
+        "ecs:Describe*",
+        "ecs:DeregisterContainerInstance",
+        "ecs:UpdateContainerInstancesState",
+        "ecs:RegisterTaskDefinition",
+        "ecs:CreateService",
+        "application-autoscaling:PutScalingPolicy",
+        "application-autoscaling:RegisterScalableTarget",
+        "application-autoscaling:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessBatch",
+      "Action": [
+        "batch:List*",
+        "batch:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessOpsWorks",
+      "Action": [
+        "opsworks:DeregisterInstance",
+        "opsworks:DescribeInstances",
+        "opsworks:DescribeStacks",
+        "opsworks:DescribeLayers"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessCodeDeploy",
+      "Action": [
+        "codedeploy:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessGeneralS3",
+      "Action": [
+        "s3:GetObject",
+        "s3:List*",
+        "s3:GetBucketLocation"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccessRoute53",
+      "Action": [
+        "route53:ListHostedZones",
+        "route53:ListResourceRecordSets",
+        "route53:ChangeResourceRecordSets"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "AccesS3forElasticBeanstalk",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::elasticbeanstalk*"
+      ]
+    },
+    {
+      "Sid": "DockerBasedBeanstalkEnvironments",
+      "Action": [
+        "ecs:Poll",
+        "ecs:DiscoverPollEndpoint",
+        "ecs:StartTelemetrySession",
+        "ecs:StartTask",
+        "ecs:StopTask",
+        "ecs:DescribeContainerInstances",
+        "ecs:RegisterContainerInstance",
+        "ecs:DeregisterContainerInstance",
+        "ecs:SubmitContainerStateChange",
+        "ecs:SubmitTaskStateChange"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "spotinst_role" {
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${var.spotinst_account_id}:root"]
+    }
+
+    actions = ["sts:AssumeRole"]
+
+    condition {
+      test = "StringEquals"
+      variable = "sts:ExternalId"
+      values = [var.spotinst_external_id]
+    }
+  }
+}
+
+
+resource "aws_iam_role" "spotinst_role" {
+  name = "SpotinstRole"
+  assume_role_policy = data.aws_iam_policy_document.spotinst_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "spotinst_role_policy" {
+  policy_arn = aws_iam_policy.spotinst_policy.arn
+  role = aws_iam_role.spotinst_role.name
+}

--- a/spotinst_aws_connection/outputs.tf
+++ b/spotinst_aws_connection/outputs.tf
@@ -1,0 +1,3 @@
+output "spotinst_role_arn" {
+  value = aws_iam_role.spotinst_role.arn
+}

--- a/spotinst_aws_connection/variables.tf
+++ b/spotinst_aws_connection/variables.tf
@@ -1,0 +1,9 @@
+variable "spotinst_account_id" {
+  type = "string"
+  description = "The AWS account id provided by Spotinst"
+}
+
+variable "spotinst_external_id" {
+  type = "string"
+  description = "The external id provided by Spotinst"
+}

--- a/spotinst_aws_connection/variables.tf
+++ b/spotinst_aws_connection/variables.tf
@@ -1,9 +1,9 @@
 variable "spotinst_account_id" {
-  type = "string"
+  type = string
   description = "The AWS account id provided by Spotinst"
 }
 
 variable "spotinst_external_id" {
-  type = "string"
+  type = string
   description = "The external id provided by Spotinst"
 }


### PR DESCRIPTION
Hey there,

since I am in the process of creating a multi-account AWS setup which I want to integrate with Spotinst I created this handy module for setting up IAM resources accordingly. By providing the Spotinst account id and external id from the web interface (new account > manual setup) you can easily manage the required resources via Terraform as well.

Eager to hear feedback or see this included in the official project!