### PR TITLE
fix missing rbac for storageclasses

### DIFF
--- a/spotinst_ocean_controller/main.tf
+++ b/spotinst_ocean_controller/main.tf
@@ -76,6 +76,12 @@ resource "kubernetes_cluster_role" "default" {
   }
 
   rule {
+    api_groups = ["storage.k8s.io"]
+    resources = ["storageclasses"]
+    verbs = ["get", "list", "watch"]
+  }
+
+  rule {
     non_resource_urls = ["/version/", "/version"]
     verbs = ["get"]
   }


### PR DESCRIPTION
Hi, 

looks like the terraform module is missing the recent additions to the rbac permissions for `storageclasses`.

This is fixed in this PR.