### PR TITLE
Add support for Terraform 0.12 for spotinst_ocean_controller

### DIFF
--- a/spotinst_ocean_controller/main.tf
+++ b/spotinst_ocean_controller/main.tf
@@ -4,7 +4,7 @@ resource "kubernetes_config_map" "configmap" {
     namespace = "kube-system"
   }
 
-  data {
+  data = {
     spotinst.token = "${var.spotinst_token}"
     spotinst.account  = "${var.spotinst_account}"
     spotinst.cluster-identifier = "${var.spotinst_cluster_identifier}"
@@ -15,7 +15,7 @@ resource "kubernetes_secret" "default" {
   metadata {
     name = "spotinst-kubernetes-cluster-controller-certs"
     namespace = "kube-system"
-    labels {
+    labels = {
       k8s-app = "spotinst-kubernetes-cluster-controller"
     }
   }
@@ -26,7 +26,7 @@ resource "kubernetes_service_account" "default" {
   metadata {
     name = "spotinst-kubernetes-cluster-controller"
     namespace = "kube-system"
-    labels {
+    labels = {
       k8s-app = "spotinst-kubernetes-cluster-controller"
     }
   }
@@ -123,7 +123,7 @@ resource "kubernetes_deployment" "default" {
   metadata {
     name = "spotinst-kubernetes-cluster-controller"
     namespace = "kube-system"
-    labels {
+    labels = {
       k8s-app = "spotinst-kubernetes-cluster-controller"
     }
   }
@@ -132,14 +132,14 @@ resource "kubernetes_deployment" "default" {
     replicas = 1
     revision_history_limit = 10
     selector {
-      match_labels {
+      match_labels = {
         k8s-app = "spotinst-kubernetes-cluster-controller"
       }
     }
 
     template {
       metadata {
-        labels {
+        labels = {
           k8s-app = "spotinst-kubernetes-cluster-controller"
         }
       }

--- a/spotinst_ocean_controller/main.tf
+++ b/spotinst_ocean_controller/main.tf
@@ -213,7 +213,8 @@ resource "kubernetes_deployment" "default" {
         }
         volume {
           name = "tmp-volume"
-          empty_dir = {}
+          empty_dir {
+          }
         }
 
 

--- a/spotinst_ocean_controller/main.tf
+++ b/spotinst_ocean_controller/main.tf
@@ -5,9 +5,9 @@ resource "kubernetes_config_map" "configmap" {
   }
 
   data = {
-    spotinst.token = "${var.spotinst_token}"
-    spotinst.account  = "${var.spotinst_account}"
-    spotinst.cluster-identifier = "${var.spotinst_cluster_identifier}"
+    "spotinst.token" = "${var.spotinst_token}"
+    "spotinst.account"  = "${var.spotinst_account}"
+    "spotinst.cluster-identifier" = "${var.spotinst_cluster_identifier}"
   }
 }
 


### PR DESCRIPTION
Adds support for the new syntax of Terraform 0.12 for `spotinst_ocean_controller`. It could be breaking for 0.11.