### PR TITLE
Adding support for EKS cluster_version

### DIFF
--- a/spotinst_ocean_eks/examples/example.tf
+++ b/spotinst_ocean_eks/examples/example.tf
@@ -28,4 +28,5 @@ module "spotinst_ocean_eks" {
 
   ami         = "${var.ami}"
   key_name    = "${var.key_name}"
+  cluster_version = "${var.cluster_version}"
 }

--- a/spotinst_ocean_eks/examples/variables.tf
+++ b/spotinst_ocean_eks/examples/variables.tf
@@ -34,3 +34,7 @@ variable "min_size" {
 variable "max_size" {
   default = 1000
 }
+
+variable "cluster_version" {
+  default = "1.14"
+}

--- a/spotinst_ocean_eks/main.tf
+++ b/spotinst_ocean_eks/main.tf
@@ -78,6 +78,7 @@ module "eks" {
   version            = "v4.0.2" # requiered for terraform version < 0.12
   source             = "terraform-aws-modules/eks/aws"
   cluster_name       = "${local.cluster_name}"
+  cluster_version    = "${var.cluster_version}"
   subnets            = ["${module.vpc.private_subnets}"]
   tags               = "${local.tags}"
   vpc_id             = "${module.vpc.vpc_id}"


### PR DESCRIPTION
As of now, our module has this variable configured but it is not being sent to the AWS EKS module we use to create the EKS cluster.

This fix adds that support + updates the example files accordingly.